### PR TITLE
Build with gradle in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-src/
 target/
 .gradle/
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+FROM gradle:alpine as builder
+USER root
+ADD . /home/gradle/project
+WORKDIR /home/gradle/project
+RUN gradle --stacktrace assemble
+
 FROM openjdk:8-jdk-alpine
-COPY build/libs/app-0.0.1.jar /app.jar
+COPY --from=0 /home/gradle/project/build/libs/app-0.0.1.jar /app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
     volumes:
-      - /world:opt/world
+      - /world:/opt/world
       - /resources/tiles:/opt/tiles
     ports:
       - 8080:8080


### PR DESCRIPTION
Hey there! I added a multistep to dockerfile to be able to build without installing `gradle`. 

If you don't want this change we could add this to the readme instead:
```
docker run -u root --rm -v "$PWD":/home/gradle/project -w /home/gradle/project gradle gradle assemble
```
